### PR TITLE
update to skylab v4 tags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # genericMarine (JEDI based generic DA using file I/O)
 ################################################################################
 cmake_minimum_required( VERSION 3.12 )
-project( genericMarine VERSION 2023.2.0 LANGUAGES C CXX Fortran)
+project( genericMarine VERSION 2023.4.0 LANGUAGES C CXX Fortran)
 
 find_package( ecbuild 3.6 REQUIRED)
 include( ecbuild_system NO_POLICY_SCOPE )
@@ -21,13 +21,13 @@ include( genericMarine_compiler_flags )
 # Dependencies
 ################################################################################
 find_package( NetCDF REQUIRED COMPONENTS C CXX)
-find_package( eckit  1.11.6   REQUIRED)
-find_package( fckit  0.7.0    REQUIRED)
-find_package( atlas  0.20.2   REQUIRED)
-find_package( oops   1.5.0    REQUIRED)
-find_package( saber  1.5.0    REQUIRED)
-find_package( ioda   2.4.0    REQUIRED)
-find_package( ufo    1.5.0    REQUIRED)
+find_package( eckit  1.20.2   REQUIRED)
+find_package( fckit  0.9.5    REQUIRED)
+find_package( atlas  0.31.1   REQUIRED)
+find_package( oops   1.6.0    REQUIRED)
+find_package( saber  1.6.0    REQUIRED)
+find_package( ioda   2.5.0    REQUIRED)
+find_package( ufo    1.6.0    REQUIRED)
 
 
 ################################################################################

--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -11,7 +11,7 @@ cmake_minimum_required( VERSION 3.12 )
 find_package( ecbuild 3.6 REQUIRED)
 
 # project name / version
-project( generic-marine-jedi-bundle VERSION 2023.2.0 LANGUAGES C CXX Fortran )
+project( generic-marine-jedi-bundle VERSION 2023.4.0 LANGUAGES C CXX Fortran )
 
 include( ecbuild_bundle )
 ecbuild_bundle_initialize()
@@ -19,19 +19,17 @@ ecbuild_bundle_initialize()
 
 #===================================================================================================
 # required repositories
-# The following tags are are between skylab releases, taken from latest develop dated Feb, 17 2023.
-# In the future we will use the skylab tagged releases. (Didn't do it this time because there
-# was a very large IODA change I needed to use)
+# JEDI repository versions are from SKYLAB v4 (April 13, 2023)
 #===================================================================================================
 # Useassume jedi-cmake is in the pre-built environment
 include( $ENV{jedi_cmake_ROOT}/share/jedicmake/Functions/git_functions.cmake )
 
 # repos to download
-ecbuild_bundle( PROJECT oops            GIT "https://github.com/jcsda/oops.git"            UPDATE TAG 6b49362 )
-ecbuild_bundle( PROJECT saber           GIT "https://github.com/jcsda/saber.git"           UPDATE TAG 4b1022a )
-ecbuild_bundle( PROJECT ioda            GIT "https://github.com/jcsda/ioda.git"            UPDATE TAG 6f51577 )
-#ecbuild_bundle( PROJECT ioda-converters GIT "https://github.com/jcsda/ioda-converters.git" UPDATE TAG dfd9c51 )
-ecbuild_bundle( PROJECT ufo             GIT "https://github.com/jcsda/ufo.git"             UPDATE TAG 2e69e83 )
+ecbuild_bundle( PROJECT oops            GIT "https://github.com/jcsda/oops.git"            TAG 1.6.0 )
+ecbuild_bundle( PROJECT saber           GIT "https://github.com/jcsda/saber.git"           TAG 1.6.0 )
+ecbuild_bundle( PROJECT ioda            GIT "https://github.com/jcsda/ioda.git"            TAG 2.5.0 )
+ecbuild_bundle( PROJECT ioda-converters GIT "https://github.com/jcsda/ioda-converters.git" TAG 0251b27 )
+ecbuild_bundle( PROJECT ufo             GIT "https://github.com/jcsda/ufo.git"             TAG 1.6.0 )
 ecbuild_bundle( PROJECT genericMarine   SOURCE ../)
 
 ecbuild_bundle_finalize()


### PR DESCRIPTION
Update the tagged version of the repos in the bundle to point to the latest quarterly skylab release. Checked with the latest skylabv4 modules (though everything should still work with the skylabv3 modules as well).


* closes https://github.com/travissluka/generic-marine-jedi/issues/10
